### PR TITLE
Nested groups and disabled users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# ldap-reader
+
+Python LDAP module for listing accounts and authenticating them against LDAP servers.
+It wraps `python-ldap` and provides an API that is LDAP vendor independent.
+
+## Features
+
+- Lists accounts within LDAP `Group`s and `OrganizationalUnit`s (OUs).
+- Supports Microsoft Active Directory, Red Hat Directory Server/389 Directory Server and OpenLDAP.
+- Validate account credentials.
+
+## Usage
+
+Print all users on a group 'MyGroup' on LDAP server for 'example.com': 
+
+```
+import ldap_reader
+
+config = {
+    'server_type': 'AD', # Microsoft Active Directory
+    'dir_username_source': 'userPrincipalName',
+    'dir_member_source': 'member',
+    'dir_fname_source': 'givenName',
+    'dir_lname_source': 'sn',
+}
+
+# Connect to the LDAP server running on host 'myldap.example.com'
+ldap_conn = ldap_reader.LdapConnection(
+    'ldap://myldap.example.com:389/', 
+    'dc=example,dc=com', 
+    'Administrator@example.com',
+    'password')
+
+# Get Group/OU
+my_group = ldap_conn.get_group(config, 'cn=MyGroup,dc=example,dc=com')
+
+# Get the Group/OU users
+users = my_group.userlist()
+assert users
+
+# Validate credentials for the first user within the group
+user = users[0]
+assert my_group.can_auth(user['email'], 'password')
+``` 
+
+## Configuration
+
+Here's the specific configuration for each vendor (this pain may be avoided if auto-detection is implemented in the future)
+
+### AD
+
+```
+config_ad = {
+    'server_type': 'AD',
+    'dir_username_source': 'userPrincipalName',
+    'dir_member_source': 'member',
+    ...
+}
+```
+
+### RHDS/389DS
+
+```
+config_rhds = {
+    'server_type': 'RHDS',
+    'dir_username_source': 'uid',
+    'dir_member_source': 'uniqueMember',
+    ...
+}
+```
+
+### OpenLDAP
+
+```
+config_openldap = {
+    'server_type': 'OpenLDAP',
+    'dir_username_source': 'uid',
+    'dir_member_source': 'member',
+    ...
+}
+```
+
+## TODO
+
+- LDAP Vendor type autodetection (this would relieve users from setting a config)
+- Make LdapGroup.userlist() work for OpenLDAP `posixGroups`.
+- More research is needed for OpenLDAP Enabled/Disabled account detection (see `ldap_reader.vendor._check_enabled_open_ldap()`).
+- Unit tests for all `ldap_reader` public methods.

--- a/ldap_reader/__init__.py
+++ b/ldap_reader/__init__.py
@@ -1,0 +1,18 @@
+''' _init__.py
+Python LDAP Reader Module
+'''
+
+__title__ = 'ldap_reader'
+__version__ = '0.1'
+
+from .reader import (
+    LdapConnection,
+    LdapOuGroup,
+    LdapGroupGroup,
+    InvalidGroupConfiguration,
+    TooManyLdapResults,
+    NotEnoughLdapResults,
+    can_auth,
+    collect_groups,
+    get_auth_username,
+)

--- a/ldap_reader/reader.py
+++ b/ldap_reader/reader.py
@@ -3,7 +3,7 @@
 Pulls the enterprise user groups from the LDAP server.
 
 (c) 2016, SpiderOak, Inc.
-This Source Code Form is subject to the terms of the Mozilla Public 
+This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, you can obtain one at http://mozilla.org/MPL/2.0/ .
 
@@ -19,14 +19,18 @@ That code (c) 2012 The OpenStack Foundation.
 
 '''
 
+from __future__ import print_function
 import ldap
 import logging
 import re
 
+import vendor
+
+
 try:
     from ldap.controls import SimplePagedResultsControl
 except ImportError:
-    print "Client LDAP does not support paged results"
+    print("Client LDAP does not support paged results")
 
 # MS ActiveDirectory does not properly give redirections; it passes
 # redirects to the LDAP library, which dutifully follows them, but
@@ -43,11 +47,13 @@ _PAGE_SIZE = 900
 # Are we going to use paged queries?
 _TRY_PAGED_QUERIES = True
 
+
 class InvalidGroupConfiguration(Exception):
     '''
     Thrown when invalid group configuration is used.
     '''
     pass
+
 
 class TooManyLdapResults(Exception):
     '''
@@ -55,80 +61,72 @@ class TooManyLdapResults(Exception):
     '''
     pass
 
+
 class NotEnoughLdapResults(Exception):
     '''
     Thrown when we don't get enough LDAP results.
     '''
     pass
 
+
 class LdapConnection(object):
+    '''
+    Represents a connection to an LDAP Server.
+    '''
+
     def __init__(self, uri, base_dn, username, password):
         log = logging.getLogger('LdapConnection __init__')
         self.conn = ldap.initialize(uri)
         self.conn.simple_bind_s(username, password)
-        log.debug("Bound to %s as %s" % (uri, username,))
+        log.debug("Bound to %s as %s", uri, username)
         self.conn.protocol_version = 3
 
         self.base_dn = base_dn
 
     def get_group(self, config, ldap_id):
+        '''
+        Returns an 'LdapGroupGroup' or 'LdapGroup' given an ldap_id.
+        Arguments:
+        config : dict
+        ldap_id : string, group/ou distinguishedName
+        '''
         group_type = self._determine_group_type(ldap_id)
         if group_type == 'ou':
             return LdapOuGroup(self, config, ldap_id)
         elif group_type == 'group':
             return LdapGroupGroup(self, config, ldap_id)
 
-    def enabled_attrs(self):
-        '''
-        Return a list of LDAP fields determining user enable/disable status.
-
-        Each type of LDAP has its own means of tracking if a user is enabled
-        or disabled. This function will return a list of the appropriate fields
-        for the type of LDAP we are using.
-        '''
-        # TODO!
-        pass
-
-    def check_enabled(self, attrs_dict):
-        '''
-        Return boolean value of an enabled account based on the attributes given.
-
-        We expect attrs_dict to be a dictionary with keys corresponding to the
-        return value of `enabled_attrs()`. Based on per-implementation rules,
-        we will return True or False if an account is active or inactive.
-        '''
-        # TODO!
-        pass
-    
     def _determine_group_type(self, ldap_id):
         '''
-        Determines if the group we're dealing with is either an OU or an LDAP group.
+        Determines if the group we're dealing with
+        is either an OU or an LDAP group.
         '''
 
         results = self.conn.search_s(
             ldap_id,
             ldap.SCOPE_BASE,
             attrlist=['objectClass'])
-        
+
         # The following are objectTypes for OUs.
         # Possibly multiple entries come back for objectClass:
-        for objClass in results[0][1]['objectClass']:
-            if objClass in LdapGroup.ou_object_classes:
+        for obj_class in results[0][1]['objectClass']:
+            if obj_class.lower() in LdapGroup.ou_object_classes:
                 return 'ou'
 
-        else:
-            return 'group'
+        return 'group'
 
-        
+
 class LdapGroup(object):
-    ou_object_classes = set(['container', 'organizationalUnit'])  
+    '''
+    Abstract class to represent an LDAP Group/OU.
+    '''
+    ou_object_classes = set(['container', 'organizationalunit'])
 
     def __init__(self, ldap_conn, config, ldap_id):
-        log = logging.getLogger('LdapGroup __init__')
         self.ldap_conn = ldap_conn
         self.ldap_id = ldap_id
         self.config = config
-        
+
         # Locally cached list of users.
         self._users = None
 
@@ -145,10 +143,9 @@ class LdapGroup(object):
         if self.config.get('dir_email_source', None) not in (None, '',):
             attrlist.append(self.config['dir_email_source'].encode('utf-8'))
 
-        attrlist.extend(self.ldap_conn.enabled_attrs())
-        
-        return attrlist
+        attrlist.extend(vendor.enabled_attrs(self.config))
 
+        return attrlist
 
     def _build_user_dict(self, result_dict):
         """
@@ -158,35 +155,40 @@ class LdapGroup(object):
         """
 
         user = {
-            'firstname' : result_dict.get(self.config['dir_fname_source'], [' '])[0],
-            'lastname'  : result_dict.get(self.config['dir_lname_source'], [' '])[0],
+            'firstname':
+            result_dict.get(self.config['dir_fname_source'], [' '])[0],
+            'lastname':
+            result_dict.get(self.config['dir_lname_source'], [' '])[0],
         }
 
         if self.config.get('dir_email_source', None) not in (None, '',):
             user['email'] = result_dict[self.config['dir_email_source']][0]
-            user['username'] = result_dict[self.config['dir_username_source']][0]
+            user['username'] = result_dict[
+                self.config['dir_username_source']][0]
         else:
             user['email'] = result_dict[self.config['dir_username_source']][0]
 
         enabled_attrs_dict = {
-            k: result_dict[k][0] for k in self.ldap_conn.enabled_attrs()
+            k: result_dict[k][0] if k in result_dict else ''
+            for k in vendor.enabled_attrs(self.config)
         }
-        user['enabled'] = self.ldap_conn.check_enabled(enabled_attrs_dict)
+        user['enabled'] = vendor.check_enabled(
+            self.config,
+            enabled_attrs_dict)
 
         return user
-
 
     def _user_for_uid(self, uid, uid_field):
         """
         Given a UID, look up a user.
         """
-        
+
         log = logging.getLogger("_user_for_uid")
         results = self.ldap_conn.conn.search_s(
-            base      = self.config['dir_base_dn'],
-            scope     = ldap.SCOPE_SUBTREE,
-            filterstr = "(%s=%s)" % (uid_field, uid,),
-            attrlist  = self._create_attrlist())
+            base=self.config['dir_base_dn'],
+            scope=ldap.SCOPE_SUBTREE,
+            filterstr="(%s=%s)" % (uid_field, uid,),
+            attrlist=self._create_attrlist())
 
         try:
             _, result = _filter_ldap_results(results)
@@ -194,7 +196,7 @@ class LdapGroup(object):
             log.warn("No results for uid %s", uid)
             return None
         except TooManyLdapResults:
-            log.warn("Multiple results for uid %s" , uid)
+            log.warn("Multiple results for uid %s", uid)
             return None
 
         return result
@@ -203,19 +205,18 @@ class LdapGroup(object):
         """
         Given a DN, look up a user.
         """
-        
+
         user = self.ldap_conn.conn.search_s(
-                uid,
-                ldap.SCOPE_BASE,
-                attrlist = self._create_attrlist())
+            uid,
+            ldap.SCOPE_BASE,
+            attrlist=self._create_attrlist())
 
-        dn, user_dict = user[0]
+        dist_name, user_dict = user[0]
 
-        if dn is None:
+        if dist_name is None:
             return None
-        
-        return user_dict
 
+        return user_dict
 
     def _build_user_details(self, uid, uid_field=None):
         '''
@@ -241,7 +242,6 @@ class LdapGroup(object):
 
         return self._build_user_dict(user_dict)
 
-
     def __iter__(self):
         """
         Provides an iterable over the user list.
@@ -249,52 +249,77 @@ class LdapGroup(object):
         if self._users is None:
             # userlist() is a virtual method for this base class, so we
             # disable pylint complaints on userlist not existing.
-            self._users = self.userlist() #pylint: disable=E1101
+            self._users = self.userlist()  # pylint: disable=E1101
 
         for user in self._users:
             yield user
 
+
 class LdapOuGroup(LdapGroup):
+    '''
+    Represents an LDAP OU.
+    '''
+
     def __init__(self, ldap_conn, config, ldap_id):
         super(LdapOuGroup, self).__init__(ldap_conn, config, ldap_id)
 
     def userlist(self):
+        '''
+        Returns the list of users (user dicts) that belong
+        to this LDAP OrganizationalUnit.
+        '''
         log = logging.getLogger('_get_group_ou %s' % (self.ldap_id,))
-        user_list = []
-        for dn, result_dict in _PagedAsyncSearch(self.ldap_conn, 
-                                                 sizelimit=200000,
-                                                 base_dn = self.ldap_id,
-                                                 scope=ldap.SCOPE_SUBTREE,
-                                                 filterstr = "(|(objectClass=person)(objectClass=user)(objectClass=organizationalUser))",
-                                                 attrlist=self._create_attrlist()):
 
-            if dn is None or not result_dict:
+        paged_async_search = _PagedAsyncSearch(
+            self.ldap_conn,
+            sizelimit=200000,
+            base_dn=self.ldap_id,
+            scope=ldap.SCOPE_SUBTREE,
+            filterstr='(|'
+                      '(objectClass=person)'
+                      '(objectClass=user)'
+                      '(objectClass=organizationalUser))',
+            attrlist=self._create_attrlist())
+
+        user_list = []
+        for dist_name, result_dict in paged_async_search:
+            if dist_name is None or not result_dict:
                 continue
             if self.config['dir_username_source'] not in result_dict:
-                log.info("User %s lacks %s, skipping", dn, self.config['dir_username_source'])
+                log.info("User %s lacks %s, skipping", dist_name,
+                         self.config['dir_username_source'])
                 continue
 
-            log.debug("Appending user %s", result_dict[self.config['dir_username_source']][0])
+            log.debug(
+                "Appending user %s", result_dict[
+                    self.config['dir_username_source']][0])
 
             user = self._build_user_dict(result_dict)
             user_list.append(user)
 
         return user_list
-    
+
 
 class LdapGroupGroup(LdapGroup):
+    '''
+    Represents an LDAP Group.
+    '''
+
     def __init__(self, ldap_conn, config, ldap_id):
         super(LdapGroupGroup, self).__init__(ldap_conn, config, ldap_id)
 
     def _check_result_keys_for_range(self, keys):
-        # Check for a ranged result key. Scan the list of result keys
-        # and match against a regex becasue MSAD will give us results like this.
-        # See https://msdn.microsoft.com/en-us/library/cc223242.aspx .
-        r = re.compile(r"^([^;]+);range=(\d+)-(\d+|\*)$")
+        '''
+        Check for a ranged result key. Scan the list of result keys
+        and match against a regex because MSAD
+        will give us results like this.
+        See https://msdn.microsoft.com/en-us/library/cc223242.aspx.
+        '''
+        range_regex = re.compile(r"^([^;]+);range=(\d+)-(\d+|\*)$")
         result_key = self.config['dir_member_source']
         end_range = None
         for key in keys:
-            match = r.match(key)
+            match = range_regex.match(key)
             if match is not None:
                 result_key = key
                 if match.group(3) != '*':
@@ -302,17 +327,17 @@ class LdapGroupGroup(LdapGroup):
                 else:
                     end_range = None
                 break
-        
+
         return (result_key, end_range,)
 
-
-    def _pas_ranged_results_wrapper(self, startrange = None):
+    def _pas_ranged_results_wrapper(self, group_ldap_id, startrange=None):
         '''
-        Wraps PagedAsyncSearch for ranged results from our friends, Microsoft.
-
+        Recursive function that wraps PagedAsyncSearch for ranged
+        results from our friends, Microsoft.
         See https://github.com/SpiderOak/netkes/issues/32.
-
-        NOTE! This function is recursive!
+        Arguments:
+        group_ldap_id: string, a group DN.
+        Returns a list of child DNs.
         '''
         if startrange is None:
             attrstring = self.config['dir_member_source']
@@ -323,7 +348,7 @@ class LdapGroupGroup(LdapGroup):
         # We expect one and only one result here.
         results = _PagedAsyncSearch(self.ldap_conn,
                                     sizelimit=200000,
-                                    base_dn=self.ldap_id,
+                                    base_dn=group_ldap_id,
                                     scope=ldap.SCOPE_BASE,
                                     attrlist=[attrstring])
 
@@ -338,36 +363,99 @@ class LdapGroupGroup(LdapGroup):
         if not result_dict:
             return []
 
-        result_key, end_range = self._check_result_keys_for_range(result_dict.keys())
+        result_key, end_range = self._check_result_keys_for_range(
+            result_dict.keys())
         users = result_dict[result_key]
         if end_range is None:
             return users
-           
-        users.extend(self._pas_ranged_results_wrapper(end_range + 1))
+
+        users.extend(
+            self._pas_ranged_results_wrapper(
+                group_ldap_id,
+                end_range + 1))
         return users
 
+    def _check_user(self, ldap_id):
+        '''
+        Checks if the ldap_id entry is a user.
+        Arguments:
+        ldap_id : string, entry's dn
+        Returns True if the entry is a user, False otherwise
+        (e.g. False for a group)
+        '''
+        user = self.ldap_conn.conn.search_s(
+            ldap_id,
+            ldap.SCOPE_BASE,
+            filterstr='(|'
+                      '(objectClass=account)'
+                      '(objectClass=person)'
+                      '(objectClass=user)'
+                      '(objectClass=organizationalUser)'
+                      ')',
+            attrlist=[])
+
+        return len(user) > 0
+
+    # Maximum group depth to search for users within nested groups
+    _MAX_GROUP_DEPTH = 10
+
+    def _get_nested_users(self, ldap_id, depth=0):
+        '''
+        Recursive function to get the list of all
+        nested users within this LDAP group.
+        It also processes child groups within this group, via recursion.
+        This method does not work for 'posixGroups' on OpenLDAP.
+            - For AD and OpenLDAP Groups, 'member' attribute is used.
+            - For RHDS Groups, 'uniqueMember' attribute is used.
+        Arguments:
+        ldap_id : string, entry's dn.
+        Returns a list of string, each string is the DN of the user.
+        '''
+        # Get 'member/s' attribute of ldap_id
+        members = self._pas_ranged_results_wrapper(ldap_id)
+
+        # Check if 'ldap_id' is a user
+        if not members and self._check_user(ldap_id):
+            return [ldap_id]
+
+        if depth >= self._MAX_GROUP_DEPTH:
+            return []
+
+        # It's a group, therefore we need to traverse its members
+        users = []
+        for member in members:
+            sub_members = self._get_nested_users(member, depth + 1)
+            users.extend(sub_members)
+
+        return users
 
     def userlist(self):
+        '''
+        Returns the list of users (user dicts) that belong to this Group.
+        '''
         log = logging.getLogger('_get_group_group %s' % (self.ldap_id,))
         user_list = []
-        for user in self._pas_ranged_results_wrapper():
+        users = self._get_nested_users(self.ldap_id)
+        uid_source = self.config.get('dir_uid_source', None)
+        for user in users:
             log.debug("Found user %s", user)
 
-            user_details = self._build_user_details(user,
-                                                    self.config.get('dir_uid_source', None))
+            user_details = self._build_user_details(user, uid_source)
 
             if user_details is None:
                 continue
 
             # Add each user that matches
             if not user_details['firstname'] and not user_details['lastname']:
-                msg = 'Unable to process user %s. The user had no first name or last name.' % user_details
-                print msg
+                msg = 'Unable to process user %s. ' \
+                      'The user had no first name or last name.' % user_details
+                print(msg)
                 log.error(msg)
             elif user_details is not None:
                 user_list.append(user_details)
 
         return user_list
+
 
 def _filter_ldap_results(results):
     '''
@@ -378,56 +466,60 @@ def _filter_ldap_results(results):
     if len(results) < 1:
         raise NotEnoughLdapResults()
 
-    result_list = [(dn, result) for dn, result in results if dn is not None ]
+    result_list = [(dist_name, result)
+                   for dist_name, result in results if dist_name is not None]
 
     # Having more than one result for this is not good.
     if len(result_list) > 1:
         raise TooManyLdapResults()
 
     return result_list[0]
-    
+
+
 def get_auth_username(config, username):
-    """
+    '''
     Returns the appropriate username to authenticate against.
 
-    Will return either the `username` argument or a username gotten from the LDAP. 
-    """
-    # If we have no configuration telling us to lookup a different username, 
+    Will return either the `username` argument or a
+    username gotten from the LDAP.
+    '''
+    # If we have no configuration telling us to lookup a different username,
     # just return here.
-    log = logging.getLogger("get_auth_username")
-
-    if (config.get('dir_auth_username') in (None, '',) and 
-        config.get('dir_auth_source') in (None, '',)):
+    if (config.get('dir_auth_username') in (None, '',) and
+            config.get('dir_auth_source') in (None, '',)):
         return username
 
     my_ldap = LdapConnection(config['dir_uri'], config['dir_base_dn'],
-                               config['dir_user'], config['dir_password'])
+                             config['dir_user'], config['dir_password'])
 
     if config.get('dir_auth_source') == 'dn':
         results = my_ldap.conn.search_s(my_ldap.base_dn,
-                                        filterstr = '(%s=%s)' % \
-                                            (config['dir_username_source'], username,),
-                                        scope = ldap.SCOPE_SUBTREE,)
+                                        filterstr='(%s=%s)' %
+                                        (config['dir_username_source'],
+                                         username,),
+                                        scope=ldap.SCOPE_SUBTREE,)
     else:
         results = my_ldap.conn.search_s(my_ldap.base_dn,
-                                        filterstr = '(%s=%s)' % \
-                                            (config['dir_username_source'], username,),
-                                        scope = ldap.SCOPE_SUBTREE,
-                                        attrlist = [config['dir_auth_username'],])
+                                        filterstr='(%s=%s)' %
+                                        (config['dir_username_source'],
+                                         username,),
+                                        scope=ldap.SCOPE_SUBTREE,
+                                        attrlist=[
+                                            config['dir_auth_username'], ])
 
     try:
-        dn, result = _filter_ldap_results(results)
+        dist_name, result = _filter_ldap_results(results)
     except NotEnoughLdapResults:
         raise Exception("No LDAP user found for username %s" % (username,))
     except TooManyLdapResults:
-        raise Exception("Too many LDAP users found via field %s for username %s" % 
+        raise Exception("Too many LDAP users found "
+                        "via field %s for username %s" %
                         (config['dir_username_source'], username,))
 
     if config.get('dir_auth_source') == 'dn':
-        return dn
+        return dist_name
     else:
         return result[config['dir_auth_username']][0]
-
 
 
 def can_auth(config, username, password):
@@ -435,7 +527,7 @@ def can_auth(config, username, password):
     Checks the ability of the given username and password to connect to the AD.
     Returns true if valid, false if not.
     '''
-    log = logging.getLogger("can_bind")
+    log = logging.getLogger("can_auth")
     # Throw out empty passwords.
     if password == "":
         return False
@@ -444,9 +536,9 @@ def can_auth(config, username, password):
     try:
         auth_user = get_auth_username(config, username)
         conn.simple_bind_s(auth_user, password)
-    # ANY failure here results in a failure to auth.  No exceptions!
+    # ANY failure here results in a failure to auth. No exceptions!
     except Exception:
-        log.exception("Failed on LDAP bind")
+        log.debug("Failed on LDAP bind")
         return False
 
     return True
@@ -464,14 +556,14 @@ def collect_groups(conn, config):
         # Make sure we don't try to sync non-LDAP groups.
         if group['user_source'] != 'ldap':
             continue
-        ldap_group = LdapGroup.get_group(conn, config,
-                                         group['ldap_id'])
+        ldap_group = conn.get_group(config, group['ldap_id'])
         result_groups.extend(ldap_group)
 
     return result_groups
 
 
-def _PagedAsyncSearch(ldap_conn, sizelimit, base_dn, scope, filterstr='(objectClass=*)', attrlist=None):
+def _PagedAsyncSearch(ldap_conn, sizelimit, base_dn, scope,
+                      filterstr='(objectClass=*)', attrlist=None):
     """ Helper function that implements a paged LDAP search for
     the Search method below.
     Args:
@@ -495,26 +587,26 @@ def _PagedAsyncSearch(ldap_conn, sizelimit, base_dn, scope, filterstr='(objectCl
             criticality=True,
             controlValue=(_PAGE_SIZE, '')
         )
-        page_ctrl_oid=ldap.LDAP_CONTROL_PAGE_OID
+        page_ctrl_oid = ldap.LDAP_CONTROL_PAGE_OID
     else:
         paged_results_control = SimplePagedResultsControl(
             criticality=True,
             size=_PAGE_SIZE,
             cookie=''
         )
-        page_ctrl_oid=ldap.controls.SimplePagedResultsControl.controlType
-        
+        page_ctrl_oid = ldap.controls.SimplePagedResultsControl.controlType
+
     logging.debug('Paged search on %s for %s', base_dn, filterstr)
     users = []
     ix = 0
-    
-    while True: 
+
+    while True:
         if _PAGE_SIZE == 0:
             serverctrls = []
         else:
             serverctrls = [paged_results_control]
-        msgid = ldap_conn.conn.search_ext(base_dn, scope, 
-                                     filterstr, attrlist=attrlist, serverctrls=serverctrls)
+        msgid = ldap_conn.conn.search_ext(base_dn, scope,
+                                          filterstr, attrlist=attrlist, serverctrls=serverctrls)
         res = ldap_conn.conn.result3(msgid=msgid)
         unused_code, results, unused_msgid, serverctrls = res
         for result in results:
@@ -524,18 +616,18 @@ def _PagedAsyncSearch(ldap_conn, sizelimit, base_dn, scope, filterstr='(objectCl
                 break
         if sizelimit and ix >= sizelimit:
             break
-        cookie = None 
+        cookie = None
         for serverctrl in serverctrls:
             if serverctrl.controlType == page_ctrl_oid:
                 if use_old_paging_api:
                     unused_est, cookie = serverctrl.controlValue
                     if cookie:
-                        paged_results_control.controlValue = (_PAGE_SIZE, cookie)
+                        paged_results_control.controlValue = (
+                            _PAGE_SIZE, cookie)
                 else:
                     cookie = paged_results_control.cookie = serverctrl.cookie
                 break
-            
+
         if not cookie:
             break
     return users
-

--- a/ldap_reader/reader.py
+++ b/ldap_reader/reader.py
@@ -128,8 +128,9 @@ class LdapGroup(object):
 
     def _build_user_dict(self, result_dict):
         """
-        Creates a dictionary to append to the user results list, with arrangement based on
-        configuration.
+        Creates a dictionary to append to the user results list, with
+        arrangement based on configuration.
+
         """
 
         user = {
@@ -147,6 +148,10 @@ class LdapGroup(object):
 
 
     def _user_for_uid(self, uid, uid_field):
+        """
+        Given a UID, look up a user.
+        """
+        
         log = logging.getLogger("_user_for_uid")
         results = self.ldap_conn.conn.search_s(
             base      = self.config['dir_base_dn'],
@@ -166,6 +171,10 @@ class LdapGroup(object):
         return result
 
     def _user_for_dn(self, uid):
+        """
+        Given a DN, look up a user.
+        """
+        
         user = self.ldap_conn.conn.search_s(
                 uid,
                 ldap.SCOPE_BASE,
@@ -180,7 +189,8 @@ class LdapGroup(object):
 
 
     def _build_user_details(self, uid, uid_field=None):
-        '''Gathers details from the user from LDAP, and creates a user dictionary
+        '''
+        Gathers details from the user from LDAP, and creates a user dictionary
         out of that.
 
         LDAP search is abstracted out based on the uid_field passed

--- a/ldap_reader/reader.py
+++ b/ldap_reader/reader.py
@@ -78,6 +78,28 @@ class LdapConnection(object):
         elif group_type == 'group':
             return LdapGroupGroup(self, config, ldap_id)
 
+    def enabled_attrs(self):
+        '''
+        Return a list of LDAP fields determining user enable/disable status.
+
+        Each type of LDAP has its own means of tracking if a user is enabled
+        or disabled. This function will return a list of the appropriate fields
+        for the type of LDAP we are using.
+        '''
+        # TODO!
+        pass
+
+    def check_enabled(self, attrs_dict):
+        '''
+        Return boolean value of an enabled account based on the attributes given.
+
+        We expect attrs_dict to be a dictionary with keys corresponding to the
+        return value of `enabled_attrs()`. Based on per-implementation rules,
+        we will return True or False if an account is active or inactive.
+        '''
+        # TODO!
+        pass
+    
     def _determine_group_type(self, ldap_id):
         '''
         Determines if the group we're dealing with is either an OU or an LDAP group.
@@ -123,6 +145,8 @@ class LdapGroup(object):
         if self.config.get('dir_email_source', None) not in (None, '',):
             attrlist.append(self.config['dir_email_source'].encode('utf-8'))
 
+        attrlist.extend(self.ldap_conn.enabled_attrs())
+        
         return attrlist
 
 
@@ -143,6 +167,11 @@ class LdapGroup(object):
             user['username'] = result_dict[self.config['dir_username_source']][0]
         else:
             user['email'] = result_dict[self.config['dir_username_source']][0]
+
+        enabled_attrs_dict = {
+            k: result_dict[k][0] for k in self.ldap_conn.enabled_attrs()
+        }
+        user['enabled'] = self.ldap_conn.check_enabled(enabled_attrs_dict)
 
         return user
 

--- a/ldap_reader/vendor.py
+++ b/ldap_reader/vendor.py
@@ -1,0 +1,102 @@
+''' vendor.py
+Module with logic for each LDAP Vendor.
+Supported vendors/servers:
+    - Microsoft Active Directory (AD)
+    - Red Hat Directory Server (RHDS)
+    - OpenLDAP
+'''
+
+# AD 'userAccountControl' attribute flag values
+AD_ACCOUNT_DISABLE = 0x0002
+AD_LOCKOUT = 0x0010
+AD_PASSWORD_EXPIRED = 0x800000
+
+
+def _check_enabled_ad(attrs_dict):
+    '''
+    Checks 'userAccountControl' attribute,
+    https://support.microsoft.com/en-us/kb/305144.
+    The following bits are checked, if one of them is enabled,
+    then we consider the user as disabled:
+        - ACCOUNTDISABLE bit 0x0002
+        - LOCKOUT bit 0x0010
+        - PASSWORD_EXPIRED bit 0x00800000
+    '''
+    try:
+        user_account_control_str = attrs_dict['userAccountControl']
+        if not user_account_control_str:
+            return True
+        user_account_control = int(user_account_control_str)
+    except KeyError:
+        # if not present, then we consider the account enabled
+        return True
+    user_disabled = bool(user_account_control & AD_ACCOUNT_DISABLE) or \
+        bool(user_account_control & AD_LOCKOUT) or \
+        bool(user_account_control & AD_PASSWORD_EXPIRED)
+    return not user_disabled
+
+
+def _check_enabled_open_ldap(attrs_dict):
+    '''
+    Checks 'PwdAccountLockedTime' attribute,
+    http://ldapwiki.willeke.com/wiki/PwdAccountLockedTime.
+    "PwdAccountLockedTime is used to indicate
+    the account is Administratively Disabled".
+    TODO: More research is needed.
+    '''
+    enabled = True
+    try:
+        pwd_account_locked_time = attrs_dict['pwdAccountLockedTime']
+        enabled = pwd_account_locked_time in (None, '',)
+    except KeyError:
+        pass
+    return enabled
+
+
+def _check_enabled_rhds(attrs_dict):
+    '''Checks 'nsAccountLock' attribute.
+    https://access.redhat.com/documentation/en-US/
+    Red_Hat_Directory_Server/8.2/html/Administration_Guide/
+    User_Account_Management-Inactivating_Users_and_Roles.html
+    Returns False if 'nsAccountLock' is set to 'TRUE'.
+    '''
+    enabled = True
+    try:
+        ns_account_lock = attrs_dict['nsAccountLock']
+        enabled = ns_account_lock.lower() != "true"
+    except KeyError:
+        # if not present, then account is enabled
+        pass
+    return enabled
+
+_SERVER_ENABLE_ATTR_MAP = {
+    'AD': (['userAccountControl'], _check_enabled_ad),
+    'RHDS': (['nsAccountLock'], _check_enabled_rhds),
+    'OpenLDAP': (['pwdAccountLockedTime'], _check_enabled_open_ldap),
+}
+
+
+def enabled_attrs(config):
+    '''
+    Return a list of LDAP fields determining user enable/disable status.
+
+    Each type of LDAP has its own means of tracking if a user is enabled
+    or disabled. This function will return a list of the appropriate fields
+    for the type of LDAP we are using.
+    '''
+    server_type = config['server_type']
+    return _SERVER_ENABLE_ATTR_MAP[server_type][0]
+
+
+def check_enabled(config, attrs_dict):
+    '''
+    Return boolean value of an enabled account
+    based on the attributes given.
+
+    We expect attrs_dict to be a dictionary with
+    keys corresponding to the return value of `enabled_attrs()`.
+    Based on per-implementation rules, we will return True or False
+    if an account is active or inactive.
+    '''
+    server_type = config["server_type"]
+    return _SERVER_ENABLE_ATTR_MAP[server_type][1](attrs_dict)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,1 @@
 python-ldap
-mock

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+
+setup(name = 'ldap-reader',
+      version = '0.1',
+      package_dir = { 'ldap_reader': 'ldap_reader' },
+      packages = [ 'ldap_reader' ],
+      install_requires = [ 'python-ldap' ],
+      keywords = [ 'spideroak', 'ldap' ],
+      description = 'ldap-reader is a module for listing accounts' \
+                    ' and authenticating them against LDAP.',
+)

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -1,40 +1,47 @@
+#! /usr/bin/env python
+''' test_reader.py
+Unit Tests for the ldap_reader module
+'''
+
 import unittest
 from mock import patch, Mock, MagicMock, sentinel
 
-from ldap_reader import reader
+from ldap_reader import reader, vendor
+
 
 class TestLdapConnection(unittest.TestCase):
-        
+
     @patch('ldap.initialize')
-    def test_connection_creation(self, ldapMod):
+    def test_connection_creation(self, ldap_mod):
         con = reader.LdapConnection('aaa', 'bbb', 'ccc', 'ddd')
 
         self.assertEqual(con.base_dn, 'bbb')
 
     @patch('ldap.initialize')
-    def test_connection_failure(self, ldapMod):
-        ldapMod.side_effect = Exception('broken connection')
+    def test_connection_failure(self, ldap_mod):
+        ldap_mod.side_effect = Exception('broken connection')
 
         with self.assertRaises(Exception):
-            con = reader.LdapConnection('aaa', 'bbb', 'ccc', 'ddd')
+            reader.LdapConnection('aaa', 'bbb', 'ccc', 'ddd')
 
     @patch('ldap.initialize')
-    def test_auth_failure(self, ldapMod):
+    def test_auth_failure(self, ldap_mod):
         mockcon = Mock()
         mockcon.simple_bind_s.side_effect = Exception('bad credentials')
-        
-        ldapMod.return_value = mockcon
+
+        ldap_mod.return_value = mockcon
 
         with self.assertRaises(Exception):
-            con = reader.LdapConnection('aaa', 'bbb', 'ccc', 'ddd')
+            reader.LdapConnection('aaa', 'bbb', 'ccc', 'ddd')
 
     @patch('ldap_reader.reader.LdapGroupGroup')
     @patch('ldap_reader.reader.LdapOuGroup')
     @patch('ldap_reader.reader.LdapConnection._determine_group_type')
     @patch('ldap.initialize')
-    def test_get_group_correct_type_for_ou(self, ldapMod, d_grp_typ, l_ou_grp, l_grp_grp):
+    def test_get_group_correct_type_for_ou(
+            self, ldap_mod, d_grp_typ, l_ou_grp, l_grp_grp):
         d_grp_typ.return_value = "ou"
-        
+
         l_ou_grp.return_value = sentinel.ougrp
         l_grp_grp.return_value = sentinel.grpgrp
 
@@ -47,9 +54,10 @@ class TestLdapConnection(unittest.TestCase):
     @patch('ldap_reader.reader.LdapOuGroup')
     @patch('ldap_reader.reader.LdapConnection._determine_group_type')
     @patch('ldap.initialize')
-    def test_get_group_correct_type_for_group(self, ldapMod, d_grp_typ, l_ou_grp, l_grp_grp):
+    def test_get_group_correct_type_for_group(
+            self, ldap_mod, d_grp_typ, l_ou_grp, l_grp_grp):
         d_grp_typ.return_value = "group"
-        
+
         l_ou_grp.return_value = sentinel.ougrp
         l_grp_grp.return_value = sentinel.grpgrp
 
@@ -63,10 +71,11 @@ class TestLdapOuGroup(unittest.TestCase):
 
     def setUp(self):
         self.config = {
+            'server_type': 'AD',
             'dir_username_source': 'userPrincipalName',
             'dir_fname_source': 'givenName',
             'dir_lname_source': 'sn',
-            }
+        }
 
         self.ldap_results = [
             ('CN=Test1,CN=users,DC=test,DC=local',
@@ -86,27 +95,35 @@ class TestLdapOuGroup(unittest.TestCase):
         ]
 
         self.group_results = [
-            { 'email': 'Test1@test.local',
-              'firstname': 'Billy',
-              'lastname': 'Tester',
-            },
-            { 'email': 'Test2@test.local',
-              'firstname': 'Dead',
-              'lastname': 'Beef',
-            },
-            { 'email': 'robot@test.local',
-              'firstname': ' ',
-              'lastname': ' ',
-            },
+            {'email': 'Test1@test.local',
+             'firstname': 'Billy',
+             'lastname': 'Tester',
+             'enabled': True,
+             },
+            {'email': 'Test2@test.local',
+             'firstname': 'Dead',
+             'lastname': 'Beef',
+             'enabled': True,
+             },
+            {'email': 'robot@test.local',
+             'firstname': ' ',
+             'lastname': ' ',
+             'enabled': True,
+             },
         ]
-        
+
     @patch('ldap_reader.reader._PagedAsyncSearch')
     def test_userlist(self, mock_pas):
         mock_pas.return_value = self.ldap_results
 
-        grp = reader.LdapOuGroup(MagicMock(), self.config, sentinel.ldap_id)
+        # Mock LdapConnection.check_enabled() to return True
+        mock_ldap_conn = MagicMock()
+        mock_ldap_conn.check_enabled.return_value = True
+
+        grp = reader.LdapOuGroup(
+            mock_ldap_conn, self.config, sentinel.ldap_id)
         users = grp.userlist()
-        
+
         self.assertEqual(self.group_results, users)
 
     @patch('ldap_reader.reader._PagedAsyncSearch')
@@ -114,13 +131,152 @@ class TestLdapOuGroup(unittest.TestCase):
         mock_pas.return_value = self.ldap_results
         mock_pas.side_effect = Exception('TestException')
 
-        grp = reader.LdapOuGroup(MagicMock(), self.config, sentinel.ldap_id)
+        grp = reader.LdapOuGroup(
+            MagicMock(), self.config, sentinel.ldap_id)
 
         with self.assertRaises(Exception):
-            users = grp.userlist()
-        
-        self.assertEqual(self.group_results, users)
-    
+            grp.userlist()
+
+
+class TestLdapGroupGroup(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {
+            'server_type': 'AD',
+            'dir_member_source': 'member',
+            'dir_username_source': 'userPrincipalName',
+            'dir_fname_source': 'givenName',
+            'dir_lname_source': 'sn',
+        }
+
+        self.get_nested_users_results = [
+            'CN=Test1,CN=users,DC=test,DC=local',
+            'CN=Test2,CN=users,DC=test,DC=local',
+            'CN=Robot,CN=users,DC=test,DC=local',
+        ]
+
+        self.return_test1 = {
+            'userPrincipalName': ['Test1@test.local'],
+            'givenName': ['Billy'],
+            'sn': ['Tester'],
+            'userAccountControl': [512],
+        }
+        self.return_test2 = {
+            'userPrincipalName': ['Test2@test.local'],
+            'givenName': ['Dead'],
+            'sn': ['Beef'],
+            'userAccountControl': [512],
+        }
+        self.return_robot = {
+            'userPrincipalName': ['robot@test.local']
+        }
+
+        self.group_results = [
+            {'email': 'Test1@test.local',
+             'firstname': 'Billy',
+             'lastname': 'Tester',
+             'enabled': True,
+             },
+            {'email': 'Test2@test.local',
+             'firstname': 'Dead',
+             'lastname': 'Beef',
+             'enabled': True,
+             },
+            {'email': 'robot@test.local',
+             'firstname': ' ',
+             'lastname': ' ',
+             'enabled': True,
+             },
+        ]
+
+    @patch('ldap_reader.reader.LdapGroup._user_for_dn')
+    @patch('ldap_reader.reader.LdapGroupGroup._get_nested_users')
+    def test_userlist(self, mock_get_nested_users, mock_user_for_dn):
+        '''
+        Generic test case for LdapGroupGroup.userlist().
+        '''
+        mock_get_nested_users.return_value = self.get_nested_users_results
+        mock_user_for_dn.side_effect = [
+            self.return_test1,
+            self.return_test2,
+            self.return_robot]
+        mock_ldap_conn = MagicMock()
+        mock_ldap_conn.check_enabled.return_value = True
+        group = reader.LdapGroupGroup(
+            mock_ldap_conn, self.config, sentinel.ldap_id)
+
+        self.assertEqual(group.userlist(), self.group_results)
+
+
+class TestVendor(unittest.TestCase):
+
+    def setUp(self):
+        self.config_ad = {
+            'server_type': 'AD',
+        }
+
+        self.config_rhds = {
+            'server_type': 'RHDS',
+        }
+
+        self.config_openldap = {
+            'server_type': 'OpenLDAP',
+        }
+
+    def test_enabled_attrs(self):
+        '''
+        Test enabled_attrs for AD, RHDS and OpenLDAP.
+        '''
+        self.assertEqual(
+            vendor.enabled_attrs(self.config_ad),
+            ['userAccountControl']
+        )
+        self.assertEqual(
+            vendor.enabled_attrs(self.config_rhds),
+            ['nsAccountLock']
+        )
+        self.assertEqual(
+            vendor.enabled_attrs(self.config_openldap),
+            ['pwdAccountLockedTime']
+        )
+
+    def test_check_enabled(self):
+        '''
+        Test check_enabled for AD, RHDS and OpenLDAP.
+        '''
+        # AD
+        self.assertEqual(
+            vendor.check_enabled(self.config_ad, {
+                'userAccountControl': 0x100  # Normal Account
+            }),
+            True)
+        self.assertEqual(
+            vendor.check_enabled(self.config_ad, {
+                'userAccountControl': 0x102  # Disabled Account
+            }),
+            False)
+        self.assertEqual(
+            vendor.check_enabled(self.config_ad, {
+                'userAccountControl': 0x110  # Locked Account
+            }),
+            False)
+
+        # RHDS
+        self.assertEqual(
+            vendor.check_enabled(self.config_rhds, {
+                'nsAccountLock': 'true',
+            }),
+            False)
+        self.assertEqual(vendor.check_enabled(self.config_rhds, {}), True)
+
+        # OpenLDAP
+        self.assertEqual(vendor.check_enabled(self.config_openldap, {}), True)
+        self.assertEqual(
+            vendor.check_enabled(self.config_openldap, {
+                'pwdAccountLockedTime': '20320101000000Z',
+            }),
+            False)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Add README.md
- Add group nested search, LdapGroup._get_nested_users() (only TODO is for 'posixGroups' on OpenLDAP)
- Add enabled/disabled account detection (vendor.py)
- Add setup.py/cfg, moved requirements.txt to requirements/  
- pylinted/documented/reformatted code (+ fixed pyflakes checks)
- Code tested on 389-ds, AD and OpenLDAP.
