### PR TITLE
Return user 'uniqueid' with entry UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It wraps `python-ldap` and provides an API that is LDAP vendor independent.
 
 Print all users on a group 'MyGroup' on LDAP server for 'example.com': 
 
-```
+```python
 import ldap_reader
 
 config = {
@@ -49,33 +49,36 @@ Here's the specific configuration for each vendor (this pain may be avoided if a
 
 ### AD
 
-```
+```python
 config_ad = {
     'server_type': 'AD',
     'dir_username_source': 'userPrincipalName',
     'dir_member_source': 'member',
+    'dir_guid_source': 'objectGUID',
     ...
 }
 ```
 
 ### RHDS/389DS
 
-```
+```python
 config_rhds = {
     'server_type': 'RHDS',
     'dir_username_source': 'uid',
     'dir_member_source': 'uniqueMember',
+    'dir_guid_source': 'nsuniqueid',
     ...
 }
 ```
 
 ### OpenLDAP
 
-```
+```python
 config_openldap = {
     'server_type': 'OpenLDAP',
     'dir_username_source': 'uid',
     'dir_member_source': 'member',
+    'dir_guid_source': 'entryUUID',
     ...
 }
 ```

--- a/ldap_reader/reader.py
+++ b/ldap_reader/reader.py
@@ -138,10 +138,12 @@ class LdapGroup(object):
         attrlist = [self.config['dir_username_source'].encode('utf-8'),
                     self.config['dir_fname_source'].encode('utf-8'),
                     self.config['dir_lname_source'].encode('utf-8'),
+                    self.config['dir_guid_source'].encode('utf-8'),
                     ]
 
-        if self.config.get('dir_email_source', None) not in (None, '',):
-            attrlist.append(self.config['dir_email_source'].encode('utf-8'))
+        email_source = self.config.get('dir_email_source', None)
+        if email_source:
+            attrlist.append(email_source.encode('utf-8'))
 
         attrlist.extend(vendor.enabled_attrs(self.config))
 
@@ -161,6 +163,7 @@ class LdapGroup(object):
             result_dict.get(self.config['dir_lname_source'], [' '])[0],
         }
 
+        # Add 'email'
         if self.config.get('dir_email_source', None) not in (None, '',):
             user['email'] = result_dict[self.config['dir_email_source']][0]
             user['username'] = result_dict[
@@ -168,6 +171,7 @@ class LdapGroup(object):
         else:
             user['email'] = result_dict[self.config['dir_username_source']][0]
 
+        # Add 'enabled'
         enabled_attrs_dict = {
             k: result_dict[k][0] if k in result_dict else ''
             for k in vendor.enabled_attrs(self.config)
@@ -175,6 +179,12 @@ class LdapGroup(object):
         user['enabled'] = vendor.check_enabled(
             self.config,
             enabled_attrs_dict)
+
+        # Add 'uniqueid'
+        guid_source = self.config.get('dir_guid_source', None)
+        result_guid = result_dict.get(guid_source, None)
+        if guid_source and result_guid:
+            user['uniqueid'] = vendor.fix_guid(self.config, result_guid[0])
 
         return user
 

--- a/ldap_reader/vendor.py
+++ b/ldap_reader/vendor.py
@@ -6,6 +6,8 @@ Supported vendors/servers:
     - OpenLDAP
 '''
 
+import uuid
+
 # AD 'userAccountControl' attribute flag values
 AD_ACCOUNT_DISABLE = 0x0002
 AD_LOCKOUT = 0x0010
@@ -54,7 +56,8 @@ def _check_enabled_open_ldap(attrs_dict):
 
 
 def _check_enabled_rhds(attrs_dict):
-    '''Checks 'nsAccountLock' attribute.
+    '''
+    Checks 'nsAccountLock' attribute.
     https://access.redhat.com/documentation/en-US/
     Red_Hat_Directory_Server/8.2/html/Administration_Guide/
     User_Account_Management-Inactivating_Users_and_Roles.html
@@ -100,3 +103,14 @@ def check_enabled(config, attrs_dict):
     '''
     server_type = config["server_type"]
     return _SERVER_ENABLE_ATTR_MAP[server_type][1](attrs_dict)
+
+
+def fix_guid(config, guid):
+    '''
+    Ensures GUIDs are properly encoded if they're from AD.
+    AD uses 'Octet String' for 'objectGUID' type.
+    '''
+    if guid and config['server_type'] == 'AD':
+        return str(uuid.UUID(bytes_le=guid))
+    else:
+        return guid

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -75,6 +75,7 @@ class TestLdapOuGroup(unittest.TestCase):
             'dir_username_source': 'userPrincipalName',
             'dir_fname_source': 'givenName',
             'dir_lname_source': 'sn',
+            'dir_guid_source': 'objectGUID',
         }
 
         self.ldap_results = [
@@ -147,6 +148,7 @@ class TestLdapGroupGroup(unittest.TestCase):
             'dir_username_source': 'userPrincipalName',
             'dir_fname_source': 'givenName',
             'dir_lname_source': 'sn',
+            'dir_guid_source': 'objectGUID',
         }
 
         self.get_nested_users_results = [
@@ -160,12 +162,18 @@ class TestLdapGroupGroup(unittest.TestCase):
             'givenName': ['Billy'],
             'sn': ['Tester'],
             'userAccountControl': [512],
+            'objectGUID':
+            [b'\x78\x56\x34\x12\x34\x12\x78\x56'
+             '\x12\x34\x56\x78\x12\x34\x56\x78'],
         }
         self.return_test2 = {
             'userPrincipalName': ['Test2@test.local'],
             'givenName': ['Dead'],
             'sn': ['Beef'],
             'userAccountControl': [512],
+            'objectGUID':
+            [b'\x56\x78\x12\x34\x12\x34\x56\x78'
+             '\x34\x56\x78\x12\x34\x56\x78\x12'],
         }
         self.return_robot = {
             'userPrincipalName': ['robot@test.local']
@@ -176,11 +184,13 @@ class TestLdapGroupGroup(unittest.TestCase):
              'firstname': 'Billy',
              'lastname': 'Tester',
              'enabled': True,
+             'uniqueid': '12345678-1234-5678-1234-567812345678',
              },
             {'email': 'Test2@test.local',
              'firstname': 'Dead',
              'lastname': 'Beef',
              'enabled': True,
+             'uniqueid': '34127856-3412-7856-3456-781234567812',
              },
             {'email': 'robot@test.local',
              'firstname': ' ',


### PR DESCRIPTION
- Returns a 'uniqueid' entry on the user dict, with the retrieved UUID.
- If it wasn't able to detect the UUID from the server, then 'uniqueid' will not be a part of the returned dict.  
