### PR TITLE
Semaphor ldap/enhancements

### DIFF
--- a/ldap_reader/reader.py
+++ b/ldap_reader/reader.py
@@ -580,13 +580,13 @@ def _filter_ldap_results(results):
     Checks LDAP results for too many or too little results.
     '''
 
-    # Make sure there's something there to begin with.
-    if len(results) < 1:
-        raise NotEnoughLdapResults()
-
     result_list = [(dist_name, result)
                    for dist_name, result in results
                    if dist_name is not None]
+
+    # Make sure there are enough results.
+    if len(result_list) < 1:
+        raise NotEnoughLdapResults()
 
     # Having more than one result for this is not good.
     if len(result_list) > 1:

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -148,7 +148,7 @@ class TestLdapOuGroup(unittest.TestCase):
             grp.userlist()
 
     @patch('ldap_reader.reader._PagedAsyncSearch')
-    def test_userlist_raises(self, mock_pas):
+    def test_userlist_no_names(self, mock_pas):
         config = {
             'server_type': self.config['server_type'],
             'dir_username_source': self.config['dir_username_source'],

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -113,6 +113,15 @@ class TestLdapOuGroup(unittest.TestCase):
              },
         ]
 
+        self.group_results_no_names = [
+            {
+                'email': user['email'],
+                'enabled': user['enabled'],
+            }
+            for user in self.group_results
+        ]
+
+
     @patch('ldap_reader.reader._PagedAsyncSearch')
     def test_userlist(self, mock_pas):
         mock_pas.return_value = self.ldap_results
@@ -138,6 +147,25 @@ class TestLdapOuGroup(unittest.TestCase):
         with self.assertRaises(Exception):
             grp.userlist()
 
+    @patch('ldap_reader.reader._PagedAsyncSearch')
+    def test_userlist_raises(self, mock_pas):
+        config = {
+            'server_type': self.config['server_type'],
+            'dir_username_source': self.config['dir_username_source'],
+            'dir_guid_source': self.config['dir_guid_source'],
+        }
+        mock_pas.return_value = self.ldap_results
+
+        # Mock LdapConnection.check_enabled() to return True
+        mock_ldap_conn = MagicMock()
+        mock_ldap_conn.check_enabled.return_value = True
+
+        grp = reader.LdapOuGroup(
+            mock_ldap_conn, config, sentinel.ldap_id,
+        )
+        users = grp.userlist()
+
+        self.assertEqual(self.group_results_no_names, users)
 
 class TestLdapGroupGroup(unittest.TestCase):
 


### PR DESCRIPTION
Support of the LDAP config without the `dir_fname_source` and `dir_lname_source` keys.
For Semaphor-LDAP 1.0 we won't be using LDAP `firstname` and `lastname` user information.
